### PR TITLE
firmware: Corrected bcdUSB device descriptor value.

### DIFF
--- a/src/usb_desc.c
+++ b/src/usb_desc.c
@@ -23,7 +23,7 @@ __code const device_descriptor_t device_descriptor =
 {
   .bLength            = 18,     // Size of this struct
   .bDescriptorType    = DEVICE_DESCRIPTOR,
-  .bcdUSB             = 2,      // USB 2.0
+  .bcdUSB             = 0x0200, // USB 2.0
   .bDeviceClass       = 0xFF,
   .bDeviceSubClass    = 0xFF,
   .bDeviceProtocol    = 0xFF,


### PR DESCRIPTION
USB 2.0 should be indicated by a value of 0x0200, per Section 9.6.1 of the USB 2.0 specification.
