### PR TITLE
Rev 2: Platform abstraction, CRPA LED heartbeat & MSPI support 

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -31,9 +31,32 @@ The following hardware has been tested and is known to work.
 
 ## Build the firmware
 
+To build generic firmware without external peripheral/IO support:
+
 ```
 make
 ```
+
+To build firmware targeting the Bitcraze Crazyradio PA:
+
+```
+make CRPA=y
+```
+
+To build firmware targeting a Bitcraze Crazyradio PA modified to be
+used as an SPI master (e.g., to use as a programmer):
+
+```
+make CRPA_MSPI=y
+```
+
+The above `CRPA_MSPI` firmware requires that U2 has been removed,
+and that pins 2 and 4 of the U2 footprint are connected. This allows
+the CSN pin to be used as an output.
+
+**IMPORTANT:** Using  the `CRPA_MSPI` firmware on an unmodified device
+may damage U2 or U3 due to contention over the CSN signal.
+
 
 ## Flash over USB
 

--- a/src/common.h
+++ b/src/common.h
@@ -1,0 +1,24 @@
+/*
+   Copyright (C) 2016 Jon Szymaniak <jon.szymaniak@gmail.com>
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef MOUSEJACK_COMMON_H_
+#define MOUSEJACK_COMMON_H_
+
+// Mark variable intentionally unused to silence associated warnings
+#define UNUSED_PARAMETER(x) ((void) (x))
+
+#endif

--- a/src/nRF24LU1P.h
+++ b/src/nRF24LU1P.h
@@ -34,7 +34,7 @@
 // Microsecond delay
 inline void delay_us(uint16_t us) { do nop_us(); while(--us); }
 
-// Shift feedback registers
+// Special Function Registers (SFR)
 __sfr __at (0xE6) rfctl;          // ref: nRF24LU1+ Product Spec, Section 6.5.1, Table 20
 __sfr __at (0x90) rfcon;          // ref: nRF24LU1+ Product Spec, Section 6.5.1, Table 21
 __sfr __at (0xA0) usbcon;         // ref: nRF24LU1+ Product Spec, Section 7.3, Table 24

--- a/src/nRF24LU1P.h
+++ b/src/nRF24LU1P.h
@@ -40,6 +40,8 @@ __sfr __at (0x90) rfcon;          // ref: nRF24LU1+ Product Spec, Section 6.5.1,
 __sfr __at (0xA0) usbcon;         // ref: nRF24LU1+ Product Spec, Section 7.3, Table 24
 __sfr __at (0x80) P0;             // ref: nRF24LU1+ Product Spec, Section 13.1, Table 94
 __sfr __at (0x94) P0DIR;          // ref: nRF24LU1+ Product Spec, Section 13.1, Table 95
+__sfr __at (0x95) P0ALT;          // ref: nRF24LU1+ Product Spec, Section 13.1, Table 96
+__sfr __at (0xC9) P0EXP;          // ref: nRF24LU1+ Product Spec, Section 13.1, Table 97
 __sfr __at (0xE5) RFDAT;          // ref: nRF24LU1+ Product Spec, Section 15.1.2, Table 108
 __sfr __at (0xAB) TICKDV;         // ref: nRF24LU1+ Product Spec, Section 19.3.2, Table 128
 __sfr __at (0xAB) REGXH;          // ref: nRF24LU1+ Product Spec, Section 19.3.6, Table 129
@@ -47,6 +49,8 @@ __sfr __at (0xAC) REGXL;          // ref: nRF24LU1+ Product Spec, Section 19.3.6
 __sfr __at (0xAD) REGXC;          // ref: nRF24LU1+ Product Spec, Section 19.3.6, Table 129
 __sfr __at (0xA8) ien0;           // ref: nRF24LU1+ Product Spec, Section 22.4.1, Table 139
 __sfr __at (0xB8) ien1;           // ref: nRF24LU1+ Product Spec, Section 22.4.2, Table 140
+__sfr __at (0xB2) SMDAT;          // ref: nrf24lu1+ product spec, Section 9.2
+__sfr __at (0xB3) SMCTRL;         // ref: nrf24lu1+ product spec, Section 9.2
 
 // SFR bits
 __sbit __at (0x90) rfce;          // ref: nRF24LU1+ Product Spec, Section 6.5.1, Table 21

--- a/src/platform.h
+++ b/src/platform.h
@@ -1,0 +1,44 @@
+/*
+  Copyright (C) 2016 Jon Szymaniak <jon.szymaniak@gmail.com>
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef MOUSEJACK_PLATFORM_H_
+#define MOUSEJACK_PLATFORM_H_
+
+#include <stdbool.h>
+
+#define PLATFORM_LED_HEARTBEAT  (1 << 0)
+#define PLATFORM_LED_DEBUG      (1 << 1)
+
+// Initialize platform-specific settings and I/O
+void platform_init();
+
+// Enable (true) or disable (false) external LN:s
+void platform_enable_lna(bool enable);
+
+// Set the state of LEDs on the platform. A `1` bit is ON, a `0` bit is OFF.
+void platform_led(uint8_t led_state);
+
+// Turn on the LEDs associated with a `1` bit the specified mask.
+void platform_led_on(uint8_t led_mask);
+
+// Turn off the LEDs associated with a `1` bit the specified mask.
+void platform_led_off(uint8_t led_mask);
+
+// Assert SPI Master chip select
+void platform_assert_spi_master_cs(bool assert_cs);
+
+#endif

--- a/src/platforms/crpa.c
+++ b/src/platforms/crpa.c
@@ -1,0 +1,93 @@
+/*
+ * Bitcraze CrazyRadio PA - Unmodified platform with LED support
+ *
+ * Copyright (C) 2016 Jon Szymaniak <jon.szymaniak@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include <stdbool.h>
+
+#include "nRF24LU1P.h"
+#include "platform.h"
+#include "common.h"
+#include "crpa.h"
+
+void platform_init()
+{
+    /* These pins must always be inputs because they're connected to the output
+     * of U2 (noninverting buffer).
+     */
+    P0DIR = (CRPA_P0_CSN | CRPA_P0_5);
+    P0 = 0;
+}
+
+void platform_enable_lna(bool enable)
+{
+    crpa_enable_lna(enable);
+}
+
+void platform_led(uint8_t leds)
+{
+    uint8_t p0_state = P0;
+
+    if (leds & PLATFORM_LED_DEBUG) {
+        p0_state |=  CRPA_P0_RED_LED2;
+    } else {
+        p0_state &= ~CRPA_P0_RED_LED2;
+    }
+
+    if (leds & PLATFORM_LED_HEARTBEAT) {
+        p0_state |=  CRPA_P0_GRN_LED1;
+    } else {
+        p0_state &= ~CRPA_P0_GRN_LED1;
+    }
+
+    P0 = p0_state;
+}
+
+void platform_led_on(uint8_t led_mask)
+{
+    uint8_t p0_state = P0;
+
+    if (led_mask & PLATFORM_LED_DEBUG) {
+        p0_state |= CRPA_P0_RED_LED2;
+    }
+
+    if (led_mask & PLATFORM_LED_HEARTBEAT) {
+        p0_state |= CRPA_P0_GRN_LED1;
+    }
+
+    P0 = p0_state;
+}
+
+void platform_led_off(uint8_t led_mask)
+{
+    uint8_t p0_state = P0;
+
+    if (led_mask & PLATFORM_LED_DEBUG) {
+        p0_state &= ~CRPA_P0_RED_LED2;
+    }
+
+    if (led_mask & PLATFORM_LED_HEARTBEAT) {
+        p0_state &= ~CRPA_P0_GRN_LED1;
+    }
+
+    P0 = p0_state;
+}
+
+// No SPI master support available in this build
+void platform_assert_spi_master_cs(bool assert_cs)
+{
+    UNUSED_PARAMETER(assert_cs);
+}

--- a/src/platforms/crpa.h
+++ b/src/platforms/crpa.h
@@ -1,0 +1,42 @@
+/*
+ * Bitcraze CrazyRadio PA common definitions
+ *
+ * Copyright (C) 2016 Jon Szymaniak <jon.szymaniak@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef CRPA_H_
+#define CRPA_H_
+
+// P0 mappning
+#define CRPA_P0_SCK      (1 << 0)
+#define CRPA_P0_MOSI     (1 << 1)
+#define CRPA_P0_MISO     (1 << 2)
+#define CRPA_P0_CSN      (1 << 3)
+#define CRPA_P0_RXEN     (1 << 4)
+#define CRPA_P0_5        (1 << 5)
+
+// LEDs are on SPI pins
+#define CRPA_P0_GRN_LED1    CRPA_P0_SCK
+#define CRPA_P0_RED_LED2    CRPA_P0_MISO
+
+#define crpa_enable_lna(enable_) do { \
+    if (enable_) { \
+        P0 |= CRPA_P0_RXEN; \
+    } else { \
+        P0 &= ~CRPA_P0_RXEN; \
+    } \
+} while (0)
+
+#endif

--- a/src/platforms/crpa_mspi.c
+++ b/src/platforms/crpa_mspi.c
@@ -1,0 +1,66 @@
+/*
+ * Modified Bitcraze CrazyRadio PA with SPI Master support
+ *
+ * IMPORTANT: This implementation assumes that U2 has been depopulated, and
+ *            U2 pins 2 & 4 have been connected. Running this firmware on an
+ *            unmodified CRPA may damage U2 and U3 (due to contention over
+ *            the CSN line).
+ *
+ *
+ * Copyright (C) 2016 Jon Szymaniak <jon.szymaniak@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "nRF24LU1P.h"
+#include "platform.h"
+#include "common.h"
+#include "crpa.h"
+
+void platform_init()
+{
+    // Configure pins for SPI Master functionality via P0EXP[0:1] = 01
+    uint8_t p0exp_val = P0EXP & ~0x3;
+    P0EXP = p0exp_val | 0x01;
+
+    // Enable SPI master
+    SMCTRL |= (1 << 4);
+
+    // Mark MISO as input, just for safe measure. This may be implicit
+    // in configuring the pin for use as an SPI master pin.
+    //
+    // P0_5 is unused - set this as an input for lack of any other use.
+    P0DIR = (CRPA_P0_MISO | CRPA_P0_5);
+
+    platform_assert_spi_master_cs(false);
+}
+
+void platform_enable_lna(bool enable)
+{
+    crpa_enable_lna(enable);
+}
+
+void platform_assert_spi_master_cs(bool assert_cs)
+{
+    if (assert_cs) {
+        P0 &= ~CRPA_P0_CSN;
+    } else {
+        P0 |= CRPA_P0_CSN;
+    }
+}
+
+// Dummies - the LED pins are not available
+void platform_led(uint8_t leds)         { UNUSED_PARAMETER(leds); }
+void platform_led_on(uint8_t led_mask)  { UNUSED_PARAMETER(led_mask); }
+void platform_led_off(uint8_t led_mask) { UNUSED_PARAMETER(led_mask); }

--- a/src/platforms/generic.c
+++ b/src/platforms/generic.c
@@ -1,0 +1,33 @@
+/*
+   Copyright (C) 2016 Jon Szymaniak <jon.szymaniak@gmail.com>
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "nRF24LU1P.h"
+#include "platform.h"
+#include "common.h"
+
+// Generic platform support - no IO support
+void platform_init()
+{
+    // Default to all pins as inpus
+    P0DIR = 0xff;
+}
+
+void platform_enable_lna(bool enable)   { UNUSED_PARAMETER(enable);     }
+void platform_led(uint8_t leds)         { UNUSED_PARAMETER(leds);       }
+void platform_led_on(uint8_t led_mask)  { UNUSED_PARAMETER(led_mask);   }
+void platform_led_off(uint8_t led_mask) { UNUSED_PARAMETER(led_mask);   }
+void platform_assert_spi_master_cs(bool assert) { UNUSED_PARAMETER(assert); }

--- a/src/radio.c
+++ b/src/radio.c
@@ -4,6 +4,7 @@
 #include "usb.h"
 #include "radio.h"
 #include "nRF24LU1P.h"
+#include "platform.h"
 
 // Enter ESB promiscuous mode
 void enter_promiscuous_mode(uint8_t * prefix, uint8_t prefix_length)
@@ -180,8 +181,7 @@ void handle_radio_request(uint8_t request, uint8_t * data)
   // Enable the LNA (CrazyRadio PA)
   else if(request == ENABLE_LNA)
   {
-    P0DIR &= ~0x10;
-    P0 |= 0x10;
+    platform_enable_lna(true);
     in1bc = 0;
     return;
   }
@@ -564,6 +564,52 @@ void handle_radio_request(uint8_t request, uint8_t * data)
     // CE high
     rfce = 1;
     in1bc = 1;
+  }
+
+  else if (request == SPI_TRANSACTION) {
+    const bool assert_csn   = (data[0] & 0x80) != 0;
+    const bool deassert_csn = (data[0] & 0x40) != 0;
+    const uint8_t len       = (data[0] & 0x1f);
+    uint8_t i = 0;
+
+    if (assert_csn) {
+        platform_assert_spi_master_cs(true);
+    }
+
+    if (len != 0) {
+        for (i = 0; i < len; i++)
+        {
+            // A delay is used here because this request handling is already
+            // executing in an IRQ context; the MSDONE IRQ cannot be used to
+            // determine when data is ready in MISO. This is admittedly sloppy,
+            // but fixing this would require that the handling of all USB
+            // requests be deferred into main() rather than done in the IRQ
+            // context.
+            //
+            // Section 10.2 of the nRF24LU1+ manual appears to indicate
+            // that IRCON.2 can be polled when operating the device
+            // as an SPI slave in non-interrupt mode. However, attempting
+            // to poll this in Master SPI mode does not appear to work.
+            // Even with INTEXP configured to enable MSDONE, no change in
+            // INTCON.2 is observed. The manual does not appear to provide any
+            // indication of whether or not INTCON.2 can be for polled MSPI.
+            //
+            // The duration of this delay was deemed to be sufficient using
+            // a Bitcraze CrazyRadio PA - this delay may need to be adjusted
+            // on a per-platform basis, depending on the speed of the
+            // system clock.
+            //
+            SMDAT = data[i+1];
+            delay_us(10);
+            in1buf[i] = SMDAT;
+        }
+    }
+
+    if (deassert_csn) {
+        platform_assert_spi_master_cs(false);
+    }
+
+    in1bc = len;
   }
 }
 

--- a/src/radio.h
+++ b/src/radio.h
@@ -100,7 +100,7 @@ __xdata static const uint8_t promiscuous_address[2] = { 0xAA, 0x00 };
 // Radio mode
 enum radio_mode_t
 {
-  // ESB sniffer mode 
+  // ESB sniffer mode
   sniffer = 0,
 
   // ESB promiscuous mode
@@ -111,7 +111,7 @@ enum radio_mode_t
 };
 
 // Radio mode
-__xdata static uint8_t radio_mode; 
+__xdata static uint8_t radio_mode;
 
 // Promiscuous mode state
 __xdata static int pm_prefix_length; // Promixcuous mode address prefix length

--- a/src/usb.h
+++ b/src/usb.h
@@ -60,6 +60,7 @@ enum usb_request_type_t
   SET_CONFIGURATION = 9,
 };
 
+
 //Vendor control messages and commands
 #define TRANSMIT_PAYLOAD               0x04
 #define ENTER_SNIFFER_MODE             0x05
@@ -72,5 +73,8 @@ enum usb_request_type_t
 #define TRANSMIT_PAYLOAD_GENERIC       0x0C
 #define ENTER_PROMISCUOUS_MODE_GENERIC 0x0D
 #define RECEIVE_PACKET                 0x12
+
+#define SPI_TRANSACTION                0x20
+
 #define LAUNCH_BOOTLOADER              0xFF
 

--- a/src/usb_desc.c
+++ b/src/usb_desc.c
@@ -18,8 +18,8 @@
 
 #include "usb_desc.h"
 
-// Device descriptor 
-__code const device_descriptor_t device_descriptor = 
+// Device descriptor
+__code const device_descriptor_t device_descriptor =
 {
   .bLength            = 18,     // Size of this struct
   .bDescriptorType    = DEVICE_DESCRIPTOR,
@@ -30,48 +30,48 @@ __code const device_descriptor_t device_descriptor =
   .bMaxPacketSize0    = 64,     // EP0 max packet size
   .idVendor           = 0x1915, // Nordic Semiconductor
   .idProduct          = 0x0102, // Nordic bootloader product ID incremebted by 1
-  .bcdDevice          = 0x0001, // Device version number 
+  .bcdDevice          = 0x0001, // Device version number
   .iManufacturer      = STRING_DESCRIPTOR_MANUFACTURER,
   .iProduct           = STRING_DESCRIPTOR_PRODUCT,
   .iSerialNumber      = 0,
   .bNumConfigurations = 1,      // Configuration count
 };
 
-// Configuration descriptor 
-__code const configuration_descriptor_t configuration_descriptor = 
+// Configuration descriptor
+__code const configuration_descriptor_t configuration_descriptor =
 {
   .bLength                = 9,     // Size of the configuration descriptor
   .bDescriptorType        = CONFIGURATION_DESCRIPTOR,
-  .wTotalLength           = 32,    // Total size of the configuration descriptor and EP/interface descriptors 
+  .wTotalLength           = 32,    // Total size of the configuration descriptor and EP/interface descriptors
   .bNumInterfaces         = 1,     // Interface count
   .bConfigurationValue    = 1,     // Configuration identifer
   .iConfiguration         = 0,
   .bmAttributes           = 0x80,  // Bus powered
-  .bMaxPower              = 100,   // Max power of 100*2mA = 200mA 
-  .interface_descriptor = 
+  .bMaxPower              = 100,   // Max power of 100*2mA = 200mA
+  .interface_descriptor =
     {
-      .bLength            = 9,    // Size of the interface descriptor 
+      .bLength            = 9,    // Size of the interface descriptor
       .bDescriptorType    = INTERFACE_DESCRIPTOR,
       .bInterfaceNumber   = 0,    // Interface index
-      .bAlternateSetting  = 0,   
+      .bAlternateSetting  = 0,
       .bNumEndpoints      = 2,    // 2 endpoints, EP1IN, EP1OUT
       .bInterfaceClass    = 0xFF, // Vendor interface class
       .bInterfaceSubClass = 0xFF, // Vendor interface subclass
       .bInterfaceProtocol = 0xFF,
       .iInterface         = 0,
     },
-  .endpoint_1_in_descriptor = 
+  .endpoint_1_in_descriptor =
     {
-      .bLength            = 7,    // Size of the endpoint descriptor 
+      .bLength            = 7,    // Size of the endpoint descriptor
       .bDescriptorType    = ENDPOINT_DESCRIPTOR,
       .bEndpointAddress   = 0x81, // EP1 IN
       .bmAttributes       = 0x02, // Bulk EP
       .wMaxPacketSize     = 64,   // 64 byte packet buffer
-      .bInterval          = 0, 
+      .bInterval          = 0,
     },
-  .endpoint_1_out_descriptor = 
+  .endpoint_1_out_descriptor =
     {
-      .bLength            = 7,    // Size of the endpoint descriptor 
+      .bLength            = 7,    // Size of the endpoint descriptor
       .bDescriptorType    = ENDPOINT_DESCRIPTOR,
       .bEndpointAddress   = 0x01, // EP1 OUT
       .bmAttributes       = 0x02, // Bulk EP
@@ -80,8 +80,8 @@ __code const configuration_descriptor_t configuration_descriptor =
     },
 };
 
-// String descriptor values 
-__code char * device_strings[3] = 
+// String descriptor values
+__code char * device_strings[3] =
 {
   "\x04\x09",          // Language (EN-US)
   "RFStorm",           // Manufacturer

--- a/src/usb_desc.h
+++ b/src/usb_desc.h
@@ -19,7 +19,7 @@
 #include <stdint.h>
 #include <stddef.h>
 
-// Descriptor types 
+// Descriptor types
 enum descriptor_type_t
 {
   DEVICE_DESCRIPTOR = 1,
@@ -37,7 +37,7 @@ enum string_descriptor_indexes_t
   STRING_DESCRIPTOR_PRODUCT,
 };
 
-// Device descriptor 
+// Device descriptor
 typedef struct {
    uint8_t  bLength;
    uint8_t  bDescriptorType;
@@ -55,49 +55,49 @@ typedef struct {
    uint8_t  bNumConfigurations;
 } device_descriptor_t;
 
-// Interface descriptor 
+// Interface descriptor
 typedef struct {
   uint8_t bLength;
   uint8_t bDescriptorType;
   uint8_t bInterfaceNumber;
   uint8_t bAlternateSetting;
-  uint8_t bNumEndpoints; 
-  uint8_t bInterfaceClass; 
-  uint8_t bInterfaceSubClass; 
+  uint8_t bNumEndpoints;
+  uint8_t bInterfaceClass;
+  uint8_t bInterfaceSubClass;
   uint8_t bInterfaceProtocol;
-  uint8_t iInterface; 
+  uint8_t iInterface;
 } interface_descriptor_t;
 
-// Endpoint descriptor 
+// Endpoint descriptor
 typedef struct {
   uint8_t  bLength;
   uint8_t  bDescriptorType;
-  uint8_t  bEndpointAddress; 
-  uint8_t  bmAttributes; 
-  uint16_t wMaxPacketSize; 
-  uint8_t  bInterval; 
+  uint8_t  bEndpointAddress;
+  uint8_t  bmAttributes;
+  uint16_t wMaxPacketSize;
+  uint8_t  bInterval;
 } endpoint_descriptor_t;
 
 // Configuration descriptor, EP1 IN and EP1 OUT
 typedef struct {
   uint8_t  bLength;
   uint8_t  bDescriptorType;
-  uint16_t wTotalLength; 
+  uint16_t wTotalLength;
   uint8_t  bNumInterfaces;
   uint8_t  bConfigurationValue;
   uint8_t  iConfiguration;
-  uint8_t  bmAttributes; 
-  uint8_t  bMaxPower; 
-  interface_descriptor_t interface_descriptor; 
-  endpoint_descriptor_t endpoint_1_in_descriptor; 
-  endpoint_descriptor_t endpoint_1_out_descriptor; 
+  uint8_t  bmAttributes;
+  uint8_t  bMaxPower;
+  interface_descriptor_t interface_descriptor;
+  endpoint_descriptor_t endpoint_1_in_descriptor;
+  endpoint_descriptor_t endpoint_1_out_descriptor;
 } configuration_descriptor_t;
 
-// Device descriptor 
-extern __code const device_descriptor_t device_descriptor; 
+// Device descriptor
+extern __code const device_descriptor_t device_descriptor;
 
-// Configuration descriptor 
-extern __code const configuration_descriptor_t configuration_descriptor; 
+// Configuration descriptor
+extern __code const configuration_descriptor_t configuration_descriptor;
 
 // Language, manufacturer, and product device strings
 extern __code char * device_strings[3];


### PR DESCRIPTION
This is rev 2 of this patch set. MSPI fixes have been squashed into the commit introducing MSPI support.

The proposed changes include the following:
- Aesthetics and comment typo fix
  - Non-functional whitespace removal performed to minimize deltas in functional changesets
- A simple platform abstraction introduced to decouple I/O and peripheral differences between platforms and builds.
  - This has been introduced to allow for CRPA builds that target either "normal" use (with an added heartbeat LED) or the SPI master mode -- both cannot be used simultaneously due to pin multiplexing constraints.
  -  `make CRPA=y` or `make CRPA_MSPI=y` is now required to target the Crazyradio PA (and use the RXEN for the LNA.
  -  `make` builds a "generic" firmware that leaves P0 as inputs.
- SPI Master support for modified CRPA platforms
  - Utilities to dump and program nRF24LU1+ devices coming in future PRs
